### PR TITLE
Upgrade project to .NET Core 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,10 @@ The `NDependSettings` have *one* mandatory option, `ProjectPath`. The remain opt
 
 ## Built With
 
-* [.NET Framework 4.6 & .NET Core 2.0](https://www.microsoft.com/net/download) - The Framework(s)
+* [.NET Core 2.0](https://www.microsoft.com/net/download) - The Framework
 * [NuGet](https://www.nuget.org/) - Dependency Management
 * [Cake](http://cakebuild.net/) - Cross Platform Build Automation System
 * [AppVeyor](https://www.appveyor.com/) - Continuous Integration & Delivery Service
-* [TravisCI](https://travis-ci.org/) - Continuous Integration Platform for GitHub
 * [NDepend](https://www.ndepend.com/) - Code Quality Platform
 
 ## Contributing

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,10 @@
-#Cake.NDepend 1.30
+#Cake.NDepend 1.5.0
+- Update `Cake.Core` dependency to version 0.35.0
+- Update the test project dependencies to the latest versions
+- Update the test project to .NET Core 3.0
+- Enforce the usage of C# 8.0, enabling non-nullable types on the addin code
+
+#Cake.NDepend 1.4.0
 - Update `Cake.Core` dependency to version 0.33.0
 - Fix the NuGet API key, due to it's renewal
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,7 +2,7 @@
 - Update `Cake.Core` dependency to version 0.35.0
 - Update the test project dependencies to the latest versions
 - Update the test project to .NET Core 3.0
-- Enforce the usage of C# 8.0, enabling non-nullable types on the addin code
+- Enforce the usage of C# 8.0
 
 #Cake.NDepend 1.4.0
 - Update `Cake.Core` dependency to version 0.33.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 environment:
   PACKAGE_KEY:
     secure: xM7MkIMHQEQgP6kf9brpWRtzazQMH+9BAIgij5HYv/FabMa1IrGnlNOPRmZkMhTk3zJ5QDEsNd+6+zA6uliK3t/3wN7j+RYmuLQO0J6BiAI=

--- a/cake-ndepend.sln
+++ b/cake-ndepend.sln
@@ -5,7 +5,6 @@ VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{BFBC8740-8631-4D0D-9DB3-CFE6645D8904}"
 	ProjectSection(SolutionItems) = preProject
-		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
 		build.cake = build.cake
 		build.ps1 = build.ps1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,6 +15,9 @@ The naming convention for the unit test project is `<code-project-name>.Tests.Un
 ## Styling guide
 We (try our best) to follow the [.NET coding style][dotnet_coding_style]. It's in our plans to integrate it into the build pipeline, producing a report. Everyone will be happy.
 
+## Releasing
+The addin is released as NuGet package. When a new tag is added to the repo, it creates the package and upload it to the official NuGet repository.
+
 [contributing_guide]: https://github.com/joaoasrosa/cake-ndepend/blob/feature/add-documentation/CONTRIBUTING.md
 [folder_structure]: https://gist.github.com/davidfowl/ed7564297c61fe9ab814
 [david_fowler]: https://twitter.com/davidfowl

--- a/src/Cake.NDepend/Cake.NDepend.csproj
+++ b/src/Cake.NDepend/Cake.NDepend.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="0.35.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.NDepend/Cake.NDepend.csproj
+++ b/src/Cake.NDepend/Cake.NDepend.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Cake.NDepend</AssemblyName>
     <RootNamespace>Cake.NDepend</RootNamespace>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cake.NDepend/Cake.NDepend.csproj
+++ b/src/Cake.NDepend/Cake.NDepend.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Cake.NDepend</AssemblyName>
     <RootNamespace>Cake.NDepend</RootNamespace>
     <LangVersion>8</LangVersion>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
+++ b/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyVersion>1.0.2</AssemblyVersion>
     <FileVersion>1.0.2</FileVersion>
     <Version>1.0.2-Documentation.1+1</Version>
+    <LangVersion>8</LangVersion>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.35.0" />

--- a/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
+++ b/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" />
-    <PackageReference Include="FluentAssertions" Version="5.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cake.NDepend\Cake.NDepend.csproj" />

--- a/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
+++ b/tests/Cake.NDepend.Tests.Unit/Cake.NDepend.Tests.Unit.csproj
@@ -7,7 +7,7 @@
     <Version>1.0.2-Documentation.1+1</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.33.0" />
+    <PackageReference Include="Cake.Core" Version="0.35.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />


### PR DESCRIPTION
This PR updates the project to .NET Core 3:
- Uses `Cake.Core` version `0.35.0`
- Updated test project dependencies
- Clean documentation and old artifacts